### PR TITLE
[FIX]: can not start the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fastify = require('fastify')({
 });
 const widgets = require('./widgets');
 const fullWidgets = require('./full-widgets');
-const prefix = 'api/v1';
+const prefix = '/api/v1';
 
 fastify.get(`${prefix}/widgets`, () => {
     return widgets;


### PR DESCRIPTION
### Changes
users can not start the server because the fastify router expects the route starts with "/" or "*"

by adding "/" to the start of the prefix variable the problem should be fixed 😉 

### Breaking Changes
nothing 🎉 

closes #3 